### PR TITLE
채팅 기능 구현: 소켓 기반 채팅 연동 및 인증 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 처리용
 
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     // https://mvnrepository.com/artifact/com.h2database/h2
     testImplementation group: 'com.h2database', name: 'h2', version: '2.3.232'
 }

--- a/src/main/java/com/bside/mzoffice/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/com/bside/mzoffice/chat/handler/ChatWebSocketHandler.java
@@ -4,22 +4,44 @@ import org.springframework.web.socket.*;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 import org.springframework.stereotype.Component;
 
+import javax.security.sasl.AuthenticationException;
 import java.io.IOException;
 
 @Component
 public class ChatWebSocketHandler extends TextWebSocketHandler {
 
     @Override
-    public void afterConnectionEstablished(WebSocketSession session) {
+    public void afterConnectionEstablished(WebSocketSession session) throws AuthenticationException {
         System.out.println("클라이언트 연결됨: " + session.getId());
+
+        Long customerId = (Long) session.getAttributes().get("customerId");
+
+        if (customerId != null) {
+            System.out.println("Authenticated user: " + customerId);
+        } else {
+            try {
+                session.close(CloseStatus.NOT_ACCEPTABLE);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            throw new AuthenticationException();
+        }
     }
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws IOException {
         System.out.println("받은 메시지: " + message.getPayload());
 
-        // 받은 메시지를 다시 클라이언트(A)에게 전송
-        session.sendMessage(new TextMessage("서버 응답: TEST "));
+        Long customerId = (Long) session.getAttributes().get("customerId");
+
+        if (customerId != null) {
+            System.out.println(customerId + " sent a message: " + message.getPayload());
+
+            // 응답 메시지 전송
+            session.sendMessage(new TextMessage("Hello " + customerId + ", your message: " + message.getPayload()));
+        } else {
+            throw new AuthenticationException();
+        }
     }
 
     @Override

--- a/src/main/java/com/bside/mzoffice/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/com/bside/mzoffice/chat/handler/ChatWebSocketHandler.java
@@ -1,0 +1,29 @@
+package com.bside.mzoffice.chat.handler;
+
+import org.springframework.web.socket.*;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class ChatWebSocketHandler extends TextWebSocketHandler {
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        System.out.println("클라이언트 연결됨: " + session.getId());
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws IOException {
+        System.out.println("받은 메시지: " + message.getPayload());
+
+        // 받은 메시지를 다시 클라이언트(A)에게 전송
+        session.sendMessage(new TextMessage("서버 응답: TEST "));
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        System.out.println("클라이언트 연결 종료: " + session.getId());
+    }
+}

--- a/src/main/java/com/bside/mzoffice/chat/interceptor/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/bside/mzoffice/chat/interceptor/WebSocketAuthInterceptor.java
@@ -1,0 +1,59 @@
+package com.bside.mzoffice.chat.interceptor;
+
+import com.bside.mzoffice.common.service.JwtService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class WebSocketAuthInterceptor implements HandshakeInterceptor {
+
+    private final JwtService jwtService;
+
+    public WebSocketAuthInterceptor(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            HttpServletRequest httpRequest = servletRequest.getServletRequest();
+//            String token = httpRequest.getHeader("Authorization");
+
+            // chrome web socket client 에서 테스트 하기 위한 코드
+            String token = httpRequest.getParameter("token");
+
+            if (token != null && token.startsWith("Bearer ")) {
+                String jwt = token.substring(7);
+                try {
+                    Claims claims = jwtService.parseToken(jwt);
+                    Long customerId = Long.valueOf(claims.getSubject()); // id 추출
+                    attributes.put("customerId", customerId);
+                } catch (Exception e) {
+                    return false; // 토큰이 유효하지 않으면 연결 거부
+                }
+            } else {
+                return false; // 토큰이 없으면 연결 거부
+            }
+        }
+        return true; // 인증 성공
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+
+    }
+}
+

--- a/src/main/java/com/bside/mzoffice/common/config/SecurityConfig.java
+++ b/src/main/java/com/bside/mzoffice/common/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         authorize ->
                                 authorize
-                                        .requestMatchers("/api/v1/auth/login/**", "/api-swagger.html", "/swagger-ui/**", "/api-docs/**")
+                                        .requestMatchers("/api/v1/auth/login/**", "/api-swagger.html", "/swagger-ui/**", "/api-docs/**", "/api/v1/chat/**")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())

--- a/src/main/java/com/bside/mzoffice/common/config/WebSocketConfig.java
+++ b/src/main/java/com/bside/mzoffice/common/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.bside.mzoffice.common.config;
+
+import com.bside.mzoffice.chat.handler.ChatWebSocketHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+    private final ChatWebSocketHandler chatHandler;
+
+    public WebSocketConfig(ChatWebSocketHandler chatHandler) {
+        this.chatHandler = chatHandler;
+    }
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(chatHandler, "/api/v1/chat").setAllowedOriginPatterns("*");
+    }
+}
+

--- a/src/main/java/com/bside/mzoffice/common/config/WebSocketConfig.java
+++ b/src/main/java/com/bside/mzoffice/common/config/WebSocketConfig.java
@@ -1,6 +1,8 @@
 package com.bside.mzoffice.common.config;
 
 import com.bside.mzoffice.chat.handler.ChatWebSocketHandler;
+import com.bside.mzoffice.chat.interceptor.WebSocketAuthInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
@@ -8,16 +10,14 @@ import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 
 @Configuration
 @EnableWebSocket
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketConfigurer {
     private final ChatWebSocketHandler chatHandler;
-
-    public WebSocketConfig(ChatWebSocketHandler chatHandler) {
-        this.chatHandler = chatHandler;
-    }
+    private final WebSocketAuthInterceptor webSocketAuthInterceptor;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(chatHandler, "/api/v1/chat").setAllowedOriginPatterns("*");
+        registry.addHandler(chatHandler, "/api/v1/chat").setAllowedOriginPatterns("*").addInterceptors(webSocketAuthInterceptor);
     }
 }
 

--- a/src/main/java/com/bside/mzoffice/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bside/mzoffice/common/filter/JwtAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       String jwt = token.substring(7);
       Claims claims = jwtService.parseToken(jwt);
 
-      Long customerId = claims.get("id", Long.class); // id 추출
+      Long customerId = Long.valueOf(claims.getSubject()); // id 추출
       UsernamePasswordAuthenticationToken authentication =
               new UsernamePasswordAuthenticationToken(
                       claims.getSubject(), null, List.of(new SimpleGrantedAuthority("ROLE_USER")));

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,16 +5,21 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/mzoffice?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
-    password: localpw
+    password:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
-        format_sql: true
-        ddl-auto: create-drop
+        format_sql: false
+        ddl-auto: none
     open-in-view: false
 
 app:
   jwtSecret: 5WOl8KinFPih9gSSZMyBkI9GBqCk1KNhZxmCHnJTT87MXf6o1Mneq/Q9QhCTTTct0cl23dRxfozp0GMGiRbKyA== #openssl rand -base64 64
+
+logging:
+  level:
+    org.hibernate: WARN
+    org.springframework: WARN


### PR DESCRIPTION
## 채팅 기능 구현

### 구현 사항:
1. **소켓 기반 채팅 연동**
   - 클라이언트가 `/api/v1/chat`으로 연결 요청 시, 서버에서 WebSocket을 통해 실시간 채팅 기능이 연동됩니다.
   - 사용자 간 실시간 메시지 송수신이 가능합니다.
   
2. **인증 처리**
   - `WebSocketAuthInterceptor`를 사용하여 WebSocket 연결 시 인증 유저인지 확인합니다.
   - 인증되지 않은 유저는 소켓 연결이 거부됩니다.

### 테스트:
- WebSocket 연결 테스트: `/api/v1/chat`으로 연결 시 인증 확인 및 정상적인 채팅 송수신이 가능한지 테스트
